### PR TITLE
Change Dependabot config to use up to date config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    default_labels:
-      - "bot: updated dependencies"
+    labels:
+      - "bot: dependencies update"
     reviewers:
       - "woocommerce/android-developers"
     ignore:


### PR DESCRIPTION
Update release notes:

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
